### PR TITLE
Use PATH_SUFFIXES to improve FindLIBHACKRF.cmake

### DIFF
--- a/host/cmake/modules/FindLIBHACKRF.cmake
+++ b/host/cmake/modules/FindLIBHACKRF.cmake
@@ -25,9 +25,10 @@ else (LIBHACKRF_INCLUDE_DIR AND LIBHACKRF_LIBRARIES)
   FIND_PATH(LIBHACKRF_INCLUDE_DIR
     NAMES hackrf.h
     HINTS $ENV{LIBHACKRF_DIR}/include ${PC_LIBHACKRF_INCLUDEDIR}
-    PATHS /usr/local/include/libhackrf /usr/include/libhackrf /usr/local/include
-    /usr/include ${CMAKE_SOURCE_DIR}/../libhackrf/src
-    /opt/local/include/libhackrf
+    PATH_SUFFIXES libhackrf
+    PATHS /usr/local/include /usr/include
+    ${CMAKE_SOURCE_DIR}/../libhackrf/src
+    /opt/local/include
     ${LIBHACKRF_INCLUDE_DIR}
   )
 


### PR DESCRIPTION
On macOS, the current version of `FindLIBHACKRF.cmake` is not able to find libhackrf, although it is correctly installed with Homebrew and pkg-config lists the package configuration.

Further investigation shows, that `LIBHACKRF_INCLUDE_DIR` is set by `pkg_check_modules` to `/opt/homebrew/Cellar/hackrf/2023.01.1/include` and the value is stored in the `PC_LIBHACKRF_INCLUDEDIR` variable. Though, the found path includes a subdirectory `libhackrf` and because it is the only path found it fails, because `hackrf.h` can not be found.

A simple solution is to use the `PATH_SUFFIXES` option for `FIND_PATH` that allows to check for this subdirectoy. Using this option also simplifies the list of search paths, because the suffix can be regarded in every path.